### PR TITLE
Add support for CR end of line as default

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-csv "2.0.2"
+(defproject com.mirego/clojure-csv "2.0.3"
   :description "A simple library to read and write CSV files."
   :dependencies [[org.clojure/clojure "1.3.0"]]
   :plugins [[perforate "0.3.2"]]

--- a/src/clojure_csv/core.clj
+++ b/src/clojure_csv/core.clj
@@ -40,6 +40,13 @@ and quotes. The main functions are parse-csv and write-csv."}
     (.reset reader)
     result))
 
+(defn- cr-at-reader-pos?
+  "Given a reader, returns true if the reader is currently pointing at an \r
+   character. Reader will not be changed when the function returns."
+  [^Reader reader]
+  (let [next-char (reader-peek reader)]
+    (== next-char (int \return))))
+
 (defn- custom-eol-at-reader-pos?
   "Given a reader and an end-of-line string, returns true if the reader is
    currently pointing at an instance of the end-of-line string. Reader will not
@@ -61,12 +68,13 @@ and quotes. The main functions are parse-csv and write-csv."}
 
 (defn- eol-at-reader-pos?
   "Given a reader and optionally an end-of-line string, returns true if the
-   reader is currently pointing at an end-of-line (LF/CRLF/the end-of-line arg).
+   reader is currently pointing at an end-of-line (LF/CRLF/CR/the end-of-line arg).
    Reader will not be changed when the function returns. Note that if the
-   EOL is specified, it will not check for LF/CRLF."
+   EOL is specified, it will not check for LF/CRLF/CR."
   ([^Reader reader]
      (or (lf-at-reader-pos? reader)
-         (crlf-at-reader-pos? reader)))
+         (crlf-at-reader-pos? reader)
+         (cr-at-reader-pos? reader)))
   ([^Reader reader end-of-line]
      (if end-of-line
        (custom-eol-at-reader-pos? reader end-of-line)
@@ -76,7 +84,7 @@ and quotes. The main functions are parse-csv and write-csv."}
   "Given a reader that is pointing at an end-of-line
    (LF/CRLF/the end-of-line arg), moves the reader forward to the
    first character after the end-of-line sequence. Note that if the EOL is
-   specified, it will not check for LF/CRLF."
+   specified, it will not check for LF/CRLF/CR."
   ([^Reader reader]
      ;; If we peek and see a newline (LF), then the EOL is just an LF, skip 1.
      ;; Otherwise, the EOL is a CRLF, so skip 2.

--- a/test/clojure_csv/test/utils.clj
+++ b/test/clojure_csv/test/utils.clj
@@ -17,8 +17,12 @@
                                                      nil)))
   (is (= true (#'clojure-csv.core/eol-at-reader-pos? (StringReader. "\r\nabc")
                                                      nil)))
-  (is (= false (#'clojure-csv.core/eol-at-reader-pos? (StringReader. "\r\tabc")
+  (is (= true (#'clojure-csv.core/eol-at-reader-pos? (StringReader. "\r\tabc")
+                                                     nil)))
+
+  (is (= false (#'clojure-csv.core/eol-at-reader-pos? (StringReader. "\t\tabc")
                                                       nil)))
+
   ;; Testing for user-specified EOLs
   (is (= true (#'clojure-csv.core/eol-at-reader-pos? (StringReader. "abc")
                                                      "abc")))


### PR DESCRIPTION
1. CR is the line-end convention used by Excel on OSX for CSV exports, so it seems to be quite common in the wild
2. end-of-line does allow passing in CR, but that requires the caller to know a-priori the convention used in the file being read
3. Adding a layer around clojure-csv to pre-test the line-end seems excessive, especially when clojure-csv is doing that anyway